### PR TITLE
Fix new/open/save features

### DIFF
--- a/satisfactor_py/base.py
+++ b/satisfactor_py/base.py
@@ -256,7 +256,7 @@ class ComponentError(Exception):
 
     def __init__(self,
         level: ComponentErrorLevel,
-        message: str,
+        message: str = '',
         **kwargs
     ):
         super().__init__(message, **kwargs)

--- a/satisfactor_ui/app.py
+++ b/satisfactor_ui/app.py
@@ -42,4 +42,4 @@ class FactoryDesigner(Gtk.Application):
         self.on_activate(app)
         if n_files > 1:
             raise ValueError('Factory Designer can open only one factory at a time')
-        self.mainWindow.load_factory(files[0].get_path())
+        self.mainWindow.load_blueprint(files[0].get_path())

--- a/satisfactor_ui/widgets.py
+++ b/satisfactor_ui/widgets.py
@@ -1,7 +1,12 @@
+import logging
+logging.basicConfig(level=logging.DEBUG)
+
 import gi
+gi.require_version('Gdk', '4.0')
 gi.require_version('Gtk', '4.0')
 
-from gi.repository import Gtk, Gio, GObject
+from gi.repository import Gdk, Gtk, Gio, GObject
+from pathlib import Path
 from satisfactor_py import (
     base,
     buildings,
@@ -16,7 +21,7 @@ from satisfactor_ui import (
 )
 
 
-def build_test_blueprint(widget: Gtk.Widget):
+def build_test_blueprint():
     '''
     Builds a simple blueprint that we can test with
     '''
@@ -39,15 +44,25 @@ def build_test_blueprint(widget: Gtk.Widget):
     convIngotsToStorage = smelter.connect(storage, conveyances.ConveyorBeltMk1)
 
     # Add them to a blueprint with coordinates, except for Conveyances, which don't need them
-    blueprint = drawing.Blueprint(widget)
+    blueprint = drawing.Blueprint()
+    blueprint.factory.name = 'Test Blueprint'
     blueprint.add_component(oreSupply, geometry.Coordinate2D(50, 20))
     blueprint.add_component(convOreToSmelter, geometry.Coordinate2D())
     blueprint.add_component(smelter, geometry.Coordinate2D(220, 20))
     blueprint.add_component(convIngotsToStorage, geometry.Coordinate2D())
     blueprint.add_component(storage, geometry.Coordinate2D(370, 20))
-    blueprint.factory.simulate()
     blueprint.viewport.scale = 1.0
     return blueprint
+
+def get_texture_from_file(filename: str) -> Gdk.Texture:
+    '''
+    Given the filename of an image, returns a Gdk.Texture object for it
+    '''
+    if Path(filename).exists():
+        texture = Gdk.Texture.new_from_filename(filename)
+        return texture
+
+    return None
 
 
 class FactoryDesignerWidget(Gtk.Widget):
@@ -60,10 +75,37 @@ class FactoryDesignerWidget(Gtk.Widget):
         blueprint: drawing.Blueprint = None
     ):
         super().__init__()
-        self.blueprint = blueprint if blueprint else drawing.Blueprint(self)
+        self.textures = {}
+        self.blueprint = blueprint if blueprint else drawing.Blueprint()
 
-        # Test components
-        self.blueprint = build_test_blueprint(self)
+    def load_texture(self,
+        filename: str,
+        category: str,
+        key: str,
+    ) -> Gdk.Texture:
+        '''
+        Loads an image into memory and stores it under the given key in the given category.
+        '''
+
+        logging.debug(f'Loading texture from filename: {filename} into {category}/{key}')
+        texture = get_texture_from_file(filename)
+        if category not in self.textures.keys():
+            self.textures[category] = {}
+        self.textures[category][key] = texture
+        logging.debug(f'Loaded texture: {texture}')
+        return texture
+
+    def get_texture(self,
+        category: str,
+        key: str
+    ) -> Gdk.Texture:
+        '''
+        Retrieves a texture from the cache, or returns None
+        '''
+
+        if category in self.textures.keys() and key in self.textures[category]:
+            return self.textures[category][key]
+        return None
 
     def do_snapshot(self,
         snapshot: Gtk.Snapshot
@@ -73,4 +115,4 @@ class FactoryDesignerWidget(Gtk.Widget):
         '''
 
         self.blueprint.viewport.size = drawing.Size2D(self.get_width(), self.get_height())
-        self.blueprint.draw_frame(snapshot)
+        self.blueprint.draw_frame(self, snapshot)


### PR DESCRIPTION
This PR moves the texture cache out of the Blueprint and into the FactoryDesignerWidget. The New/Open/Save/SaveAs features now work again, as does the "open-on-launch" feature.