### PR TITLE
Fix tagging

### DIFF
--- a/factory_designer_gtk/dialogs.py
+++ b/factory_designer_gtk/dialogs.py
@@ -410,6 +410,12 @@ class ConnectionManagementWindow(Gtk.Window):
             if active_conveyance is not None:
                 conveyance_class = getattr(conveyances, active_conveyance)
 
+        if self.current_connection:
+            old_id = self.current_connection['component'].id
+            old_index = self.current_connection['connection_index']
+        else:
+            old_id = None
+            old_index = None
         self.callback(ConnectionManagementWindowResponse(
             True,
             source_component_id=self.component.id,
@@ -417,8 +423,8 @@ class ConnectionManagementWindow(Gtk.Window):
             source_connection_is_output=self.connection.is_output(),
             target_component_id=self.cboComponent.get_active_id(),
             target_connection_index=self.cboConnection.get_active_id(),
-            old_target_component_id=self.current_connection['component'].id,
-            old_target_connection_index=self.current_connection['connection_index'],
+            old_target_component_id=old_id,
+            old_target_connection_index=old_index,
             conveyance_class=conveyance_class))
 
 

--- a/factory_designer_gtk/main_window.py
+++ b/factory_designer_gtk/main_window.py
@@ -564,8 +564,9 @@ class MainWindow(Gtk.ApplicationWindow):
                 self.boxComponentErrors.append(lbl)
 
             # Update tags listing
-            self.boxComponentTags.component = self.blueprint.selected
-            self.boxComponentTags.repopulate()
+            if self.boxComponentTags not in skip:
+                self.boxComponentTags.component = self.blueprint.selected
+                self.boxComponentTags.repopulate()
 
             # Make sure everything is visible
             self.boxComponentDetails.set_visible(True)
@@ -1693,7 +1694,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
     def __boxComponentTags_changed(self):
         self.unsaved_changes = True
-        self.update_window()
+        self.update_window(skip=[self.boxComponentTags])
 
     # + Component danger zone signal handlers
 

--- a/factory_designer_gtk/widgets.py
+++ b/factory_designer_gtk/widgets.py
@@ -334,7 +334,6 @@ class FactoryDesignerWidget(Gtk.Widget):
                 comp_x + offset_x,
                 comp_y + offset_y
             )
-            # import pdb; pdb.set_trace()
             self.component_grab_event.geometry.calculate(
                 label_height=None,
                 label_width=None,
@@ -500,11 +499,14 @@ class TagBox(Gtk.Box):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.callback = callback
         self.__component = component
+        self.__row_count = 0
 
         # Set up the outer box for packing
         self.set_halign(Gtk.Align.CENTER)
 
         self.__build()
+        if callback and component:
+            self.repopulate()
 
     @property
     def component(self):
@@ -565,11 +567,9 @@ class TagBox(Gtk.Box):
         which show component data.
         '''
 
-        logging.debug('Repopulate called')
         # Remove all rows in the grid
-        remove = 0
-        while remove is not None:
-            remove = self.gridTags.remove_row(0)
+        for i in range(self.__row_count):
+            self.gridTags.remove_row(0)
 
         if not self.component:
             return
@@ -609,6 +609,7 @@ class TagBox(Gtk.Box):
             self.gridTags.attach(lblKey, 1, i, 1, 1)
             self.gridTags.attach(lblEquals, 2, i, 1, 1)
             self.gridTags.attach(entryValue, 3, i, 1, 1)
+        self.__row_count = len(sorted_keys)
 
     def __btnNewTag_clicked(self, btn):
         key = self.entryNewTagKey.get_buffer().get_text()
@@ -628,6 +629,7 @@ class TagBox(Gtk.Box):
         self.component.tags[key] = value
         self.entryNewTagKey.get_buffer().set_text('', -1)
         self.entryNewTagValue.get_buffer().set_text('', -1)
+        self.repopulate()
         self.callback()
 
     def __btnRemoveTag_clicked(self, btn):

--- a/satisfactory/base.py
+++ b/satisfactory/base.py
@@ -201,9 +201,12 @@ class Base(object):
         availability: Availability = Availability(0, 0),
         wiki_path: str = '/Satisfactory_Wiki',
         image_path: str = None,
-        tags: dict[str, str] = dict(),
+        tags: dict[str, str] = None,
         **kwargs
     ):
+        if not tags:
+            tags = {}
+        logging.debug(f'tags: {tags}')
         if not id:
             self.id = generate_id()
         else:
@@ -726,7 +729,7 @@ class Input(Connection):
         # Connect them
         self.source = connection
         connection.target = self
-    
+
     def disconnect(self):
         self.source = None
 
@@ -791,7 +794,7 @@ class Output(Connection):
         # Connect them
         self.target = connection
         connection.source = self
-    
+
     def disconnect(self):
         self.target = None
 


### PR DESCRIPTION
I moved the tag widgets to a dedicated widget that inherits from Gtk.Box. There was also an issue where `satisfactory.base` would create a single `tags` object and then apply it by reference to every new component, causing the application of one tag to get applied to all components created that way. I fixed that by forcing the base class to create a new tags dict each time.